### PR TITLE
feat: offload slicing and estimation to workers

### DIFF
--- a/slicer-web/README.md
+++ b/slicer-web/README.md
@@ -14,7 +14,8 @@ responsive preview of print-ready layers.
 - 🧠 **Stateful viewer** – manage uploaded meshes, layer selections, and export flows with a typed
   Zustand store.
 - 📦 **Report exports** – download JSON + CSV summaries for sharing or archival.
-- 🧵 **Worker offloading** – structure Comlink workers for geometry and estimation pipelines.
+- 🧵 **Worker offloading** – lightweight clients route geometry slicing and estimation through
+  dedicated Comlink workers to keep the UI responsive.
 - 🧪 **Testing-ready** – Vitest unit suite and Playwright smoke tests with scripts wired to pnpm.
 
 ## Project structure
@@ -67,9 +68,11 @@ viewer, explore generated layers, and export reports.
 
 ## Testing
 
-Unit tests live under `tests/` and are powered by Vitest with jsdom. End-to-end smoke checks reside
-in `e2e/` and are executed by Playwright using the same pnpm workspace scripts. Configure
-`PLAYWRIGHT_BASE_URL` to point at a deployed environment when running against staging.
+Unit tests live under `tests/` and are powered by Vitest with jsdom. Worker-facing modules are
+covered with proxy stubs to ensure the Zustand store delegates geometry + estimation work to the
+background threads. End-to-end smoke checks reside in `e2e/` and are executed by Playwright using
+the same pnpm workspace scripts. Configure `PLAYWRIGHT_BASE_URL` to point at a deployed environment
+when running against staging.
 
 ## Tooling highlights
 

--- a/slicer-web/components/FileDropZone.tsx
+++ b/slicer-web/components/FileDropZone.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { useViewerStore } from '../modules/store';
 
@@ -8,6 +8,7 @@ export function FileDropZone() {
   const loadFile = useViewerStore((state) => state.loadFile);
   const loading = useViewerStore((state) => state.loading);
   const error = useViewerStore((state) => state.error);
+  const disposeWorkers = useViewerStore((state) => state.disposeWorkers);
   const [highlighted, setHighlighted] = useState(false);
 
   const handleFiles = useCallback(
@@ -19,6 +20,12 @@ export function FileDropZone() {
     },
     [loadFile]
   );
+
+  useEffect(() => {
+    return () => {
+      disposeWorkers();
+    };
+  }, [disposeWorkers]);
 
   return (
     <div

--- a/slicer-web/modules/estimate/workerClient.ts
+++ b/slicer-web/modules/estimate/workerClient.ts
@@ -1,0 +1,22 @@
+import type { WorkerHandle } from '../../lib/worker-factory';
+import { createWorkerHandle } from '../../lib/worker-factory';
+import type { EstimateWorkerApi } from '../../workers/estimate.worker';
+
+let handle: WorkerHandle<EstimateWorkerApi> | undefined;
+
+export function getEstimateWorkerHandle(): WorkerHandle<EstimateWorkerApi> {
+  if (!handle) {
+    handle = createWorkerHandle<EstimateWorkerApi>(
+      new URL('../../workers/estimate.worker.ts', import.meta.url)
+    );
+  }
+  return handle;
+}
+
+export function releaseEstimateWorker() {
+  if (!handle) {
+    return;
+  }
+  handle.terminate();
+  handle = undefined;
+}

--- a/slicer-web/modules/geometry/workerClient.ts
+++ b/slicer-web/modules/geometry/workerClient.ts
@@ -1,0 +1,22 @@
+import type { WorkerHandle } from '../../lib/worker-factory';
+import { createWorkerHandle } from '../../lib/worker-factory';
+import type { GeometryWorkerApi } from '../../workers/geometry.worker';
+
+let handle: WorkerHandle<GeometryWorkerApi> | undefined;
+
+export function getGeometryWorkerHandle(): WorkerHandle<GeometryWorkerApi> {
+  if (!handle) {
+    handle = createWorkerHandle<GeometryWorkerApi>(
+      new URL('../../workers/geometry.worker.ts', import.meta.url)
+    );
+  }
+  return handle;
+}
+
+export function releaseGeometryWorker() {
+  if (!handle) {
+    return;
+  }
+  handle.terminate();
+  handle = undefined;
+}

--- a/slicer-web/tests/unit/store.worker.test.ts
+++ b/slicer-web/tests/unit/store.worker.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BufferGeometry, Float32BufferAttribute } from 'three';
+
+import { DEFAULT_PARAMETERS } from '../../modules/estimate';
+import { useViewerStore } from '../../modules/store';
+
+const generateLayersMock = vi.fn();
+const estimateMock = vi.fn();
+var loadGeometryFromFileMock: ReturnType<typeof vi.fn>;
+
+vi.mock('../../modules/geometry/workerClient', () => ({
+  getGeometryWorkerHandle: () => ({
+    proxy: { generateLayers: generateLayersMock },
+    terminate: vi.fn(),
+    worker: {} as unknown as Worker
+  }),
+  releaseGeometryWorker: vi.fn()
+}));
+
+vi.mock('../../modules/estimate/workerClient', () => ({
+  getEstimateWorkerHandle: () => ({
+    proxy: { estimate: estimateMock },
+    terminate: vi.fn(),
+    worker: {} as unknown as Worker
+  }),
+  releaseEstimateWorker: vi.fn()
+}));
+
+vi.mock('../../modules/geometry', async () => {
+  loadGeometryFromFileMock = vi.fn();
+  const actual = await vi.importActual<typeof import('../../modules/geometry')>(
+    '../../modules/geometry'
+  );
+  return {
+    ...actual,
+    loadGeometryFromFile: loadGeometryFromFileMock
+  };
+});
+
+vi.mock('../../modules/store/persistence', () => ({
+  saveEstimate: vi.fn().mockResolvedValue(undefined),
+  loadRecentEstimates: vi.fn().mockResolvedValue([])
+}));
+
+describe('useViewerStore worker integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateLayersMock.mockReset();
+    estimateMock.mockReset();
+    loadGeometryFromFileMock?.mockReset();
+    useViewerStore.setState({
+      geometry: undefined,
+      layers: [],
+      summary: undefined,
+      parameters: { ...DEFAULT_PARAMETERS },
+      loading: false,
+      error: undefined,
+      fileName: undefined,
+      history: [],
+      geometryPayload: undefined,
+      loadFile: useViewerStore.getState().loadFile,
+      setGeometry: useViewerStore.getState().setGeometry,
+      setParameters: useViewerStore.getState().setParameters,
+      recompute: useViewerStore.getState().recompute,
+      reset: useViewerStore.getState().reset,
+      refreshHistory: useViewerStore.getState().refreshHistory,
+      disposeWorkers: useViewerStore.getState().disposeWorkers
+    });
+  });
+
+  it('delegates slicing and estimation to workers on loadFile', async () => {
+    const geometry = new BufferGeometry();
+    geometry.setAttribute(
+      'position',
+      new Float32BufferAttribute(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), 3)
+    );
+
+    loadGeometryFromFileMock!.mockResolvedValue(geometry);
+    generateLayersMock.mockResolvedValue({
+      layers: [
+        {
+          elevation: 0,
+          area: 1,
+          circumference: 2,
+          boundingRadius: 3,
+          centroid: [0, 0, 0] as [number, number, number],
+          segments: [
+            {
+              start: [0, 0, 0] as [number, number, number],
+              end: [1, 0, 0] as [number, number, number]
+            }
+          ]
+        }
+      ]
+    });
+    estimateMock.mockResolvedValue({
+      summary: {
+        volume: 1,
+        mass: 2,
+        resinCost: 3,
+        durationMinutes: 4,
+        layers: 1
+      },
+      layers: []
+    });
+
+    const file = new File([new ArrayBuffer(8)], 'cube.stl', { type: 'model/stl' });
+
+    await useViewerStore.getState().loadFile(file);
+
+    expect(loadGeometryFromFileMock).toBeDefined();
+    expect(loadGeometryFromFileMock).toHaveBeenCalledWith(file);
+    expect(generateLayersMock).toHaveBeenCalledTimes(1);
+    const [geometryRequest] = generateLayersMock.mock.calls[0];
+    expect(geometryRequest.positions).toBeInstanceOf(ArrayBuffer);
+    expect(estimateMock).toHaveBeenCalledTimes(1);
+
+    const state = useViewerStore.getState();
+    expect(state.layers).toHaveLength(1);
+    expect(state.summary?.volume).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable worker client helpers for the geometry and estimate pipelines
- delegate store slicing/estimation to the workers, wiring lifecycle cleanup and docs updates
- cover the new worker-backed flow with a Vitest store test

## Testing
- pnpm vitest run tests/unit/store.worker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc2985c7e0832c9ee562efc346455b