### PR TITLE
Treat STL files as text in gitattributes

### DIFF
--- a/slicer-web/.gitattributes
+++ b/slicer-web/.gitattributes
@@ -1,0 +1,1 @@
+*.stl text


### PR DESCRIPTION
## Summary
- ensure ASCII STL files in slicer-web are treated as text by Git

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc45ac78d4832c8b6eb9f366a4a34c