### PR TITLE
chore: treat STL assets as text

### DIFF
--- a/slicer-web/.gitattributes
+++ b/slicer-web/.gitattributes
@@ -1,1 +1,2 @@
+# Treat STL assets as text to preserve ASCII formatting
 *.stl text


### PR DESCRIPTION
## Summary
- treat `.stl` files as text assets so ASCII geometry can be diffed cleanly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4898c944832cbc484c279e6c50ec