### PR TITLE
Fix layer generation for orientations with negative components

### DIFF
--- a/slicer-web/modules/estimate/index.ts
+++ b/slicer-web/modules/estimate/index.ts
@@ -122,18 +122,24 @@ export function generateLayers(
 
   const min = bounds.min.clone();
   const max = bounds.max.clone();
-  const heightVector = max.clone().sub(min);
-  const totalHeight = Math.abs(heightVector.dot(orientation));
+  const extents = max.clone().sub(min);
+  const orientationAbs = new Vector3(Math.abs(orientation.x), Math.abs(orientation.y), Math.abs(orientation.z));
+  const totalHeight = orientationAbs.dot(extents);
 
   const layerCount = Math.max(1, Math.ceil(totalHeight / parameters.layerHeight));
   const origin = new Vector3();
+  const startCorner = new Vector3(
+    orientation.x >= 0 ? min.x : max.x,
+    orientation.y >= 0 ? min.y : max.y,
+    orientation.z >= 0 ? min.z : max.z
+  );
   const normal = orientation.clone();
 
   const layers: LayerEstimate[] = [];
 
   for (let index = 0; index < layerCount; index++) {
     const distance = parameters.layerHeight * index;
-    origin.copy(min).addScaledVector(orientation, distance);
+    origin.copy(startCorner).addScaledVector(normal, distance);
     const summary = sliceGeometry(geometry, { origin, normal, thickness: parameters.layerHeight });
     const circumference = summary.segments.reduce((acc, segment) => {
       return acc + segment.start.distanceTo(segment.end);

--- a/slicer-web/tests/unit/estimate.test.ts
+++ b/slicer-web/tests/unit/estimate.test.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, Float32BufferAttribute } from 'three';
+import { BufferGeometry, Float32BufferAttribute, Vector3 } from 'three';
 import { describe, expect, it } from 'vitest';
 import { ZodError } from 'zod';
 
@@ -44,6 +44,19 @@ describe('estimate module', () => {
     expect(layers.length).toBeGreaterThan(0);
     const centroids = layers.map((layer) => layer.centroid.length());
     expect(Math.max(...centroids)).toBeGreaterThan(0);
+  });
+
+  it('generates layers for orientations with negative components', () => {
+    const geometry = createCube(10);
+    const orientation = new Vector3(1, -1, 0).normalize();
+    const layers = generateLayers(geometry, {
+      orientation,
+      parameters: { ...DEFAULT_PARAMETERS, layerHeight: 1 }
+    });
+
+    expect(layers.length).toBeGreaterThan(10);
+    const elevations = layers.map((layer) => layer.elevation);
+    expect(Math.max(...elevations)).toBeGreaterThan(10);
   });
 
   it('estimates print metrics with reasonable numbers', () => {


### PR DESCRIPTION
## Summary
- compute layer span using bounding-box extents and the absolute normal components
- start slicing from the bounding-box corner that matches the normal direction and march along the normalized normal
- add a unit test that covers orientations containing negative components

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc4a8c4390832c98b24aa8a4f646f0