### PR TITLE
Refactor estimate worker to use shared estimateAll logic

### DIFF
--- a/slicer-web/tests/unit/store.worker.test.ts
+++ b/slicer-web/tests/unit/store.worker.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ZodError } from 'zod';
 
 import { DEFAULT_PARAMETERS } from '../../modules/estimate';
+import { DEFAULT_PRINT_PARAMS } from '../../lib/estimate';
 import { useViewerStore } from '../../modules/store';
 
 const generateLayersMock = vi.fn();
@@ -100,14 +101,21 @@ describe('useViewerStore worker integration', () => {
       ]
     });
     estimateMock.mockResolvedValue({
-      summary: {
-        volume: 1,
-        mass: 2,
-        resinCost: 3,
-        durationMinutes: 4,
-        layers: 1
-      },
-      layers: []
+      breakdown: {
+        volumeModel_mm3: 1,
+        extrudedVolume_mm3: 1.5,
+        mass_g: 2,
+        filamentLen_mm: 3,
+        time_s: 120,
+        costs: {
+          filament: 1,
+          energy: 0.5,
+          maintenance: 0.25,
+          margin: 0.1,
+          total: 1.85
+        },
+        params: DEFAULT_PRINT_PARAMS
+      }
     });
 
     const fileBuffer = new ArrayBuffer(8);
@@ -123,10 +131,12 @@ describe('useViewerStore worker integration', () => {
     const [geometryRequest] = generateLayersMock.mock.calls[0];
     expect(geometryRequest.positions).toBeInstanceOf(ArrayBuffer);
     expect(estimateMock).toHaveBeenCalledTimes(1);
+    expect(estimateMock).toHaveBeenCalledWith({ volumeModel_mm3: 0.5 });
 
     const state = useViewerStore.getState();
     expect(state.layers).toHaveLength(1);
     expect(state.summary?.volume).toBe(1);
+    expect(state.summary?.durationMinutes).toBeCloseTo(2);
   });
 
   it('captures validation errors when persistence rejects', async () => {
@@ -162,14 +172,21 @@ describe('useViewerStore worker integration', () => {
       ]
     });
     estimateMock.mockResolvedValue({
-      summary: {
-        volume: 1,
-        mass: 2,
-        resinCost: 3,
-        durationMinutes: 4,
-        layers: 1
-      },
-      layers: []
+      breakdown: {
+        volumeModel_mm3: 1,
+        extrudedVolume_mm3: 1.5,
+        mass_g: 2,
+        filamentLen_mm: 3,
+        time_s: 120,
+        costs: {
+          filament: 1,
+          energy: 0.5,
+          maintenance: 0.25,
+          margin: 0.1,
+          total: 1.85
+        },
+        params: DEFAULT_PRINT_PARAMS
+      }
     });
 
     const error = new ZodError([]);

--- a/slicer-web/workers/estimate.worker.ts
+++ b/slicer-web/workers/estimate.worker.ts
@@ -1,64 +1,20 @@
 import { expose } from 'comlink';
-import { BufferGeometry, Float32BufferAttribute, Uint32BufferAttribute, Vector3 } from 'three';
 
-import type { EstimateParameters } from '../modules/estimate';
-import { DEFAULT_PARAMETERS, generateLayers, integrateLayers } from '../modules/estimate';
+import { estimateAll, type EstimateBreakdown, type PrintParams } from '../lib/estimate';
 
 export interface EstimateWorkerRequest {
-  positions: ArrayBuffer;
-  indices?: ArrayBuffer;
-  parameters?: EstimateParameters;
+  volumeModel_mm3: number;
+  params?: Partial<PrintParams>;
 }
 
 export interface EstimateWorkerResponse {
-  summary: {
-    volume: number;
-    mass: number;
-    resinCost: number;
-    durationMinutes: number;
-    layers: number;
-  };
-  layers: Array<{
-    elevation: number;
-    area: number;
-    centroid: [number, number, number];
-    circumference: number;
-    boundingRadius: number;
-  }>;
-}
-
-function geometryFromPayload(payload: EstimateWorkerRequest): BufferGeometry {
-  const geometry = new BufferGeometry();
-  geometry.setAttribute('position', new Float32BufferAttribute(new Float32Array(payload.positions), 3));
-  if (payload.indices) {
-    geometry.setIndex(new Uint32BufferAttribute(new Uint32Array(payload.indices), 1));
-  }
-  return geometry;
+  breakdown: EstimateBreakdown;
 }
 
 const api = {
-  estimate(payload: EstimateWorkerRequest): EstimateWorkerResponse {
-    const geometry = geometryFromPayload(payload);
-    const parameters = payload.parameters ?? DEFAULT_PARAMETERS;
-    const layers = generateLayers(geometry, { parameters, orientation: new Vector3(0, 0, 1) });
-    const summary = integrateLayers(layers, parameters);
-
-    return {
-      summary: {
-        volume: summary.volume,
-        mass: summary.mass,
-        resinCost: summary.resinCost,
-        durationMinutes: summary.durationMinutes,
-        layers: summary.layers.length
-      },
-      layers: summary.layers.map((layer) => ({
-        elevation: layer.elevation,
-        area: layer.area,
-        centroid: layer.centroid.toArray() as [number, number, number],
-        circumference: layer.circumference,
-        boundingRadius: layer.boundingRadius
-      }))
-    };
+  estimate({ volumeModel_mm3, params }: EstimateWorkerRequest): EstimateWorkerResponse {
+    const breakdown = estimateAll(volumeModel_mm3, params);
+    return { breakdown };
   }
 };
 


### PR DESCRIPTION
## Summary
- expose the shared `estimateAll` helper through the estimate worker API
- adjust the viewer store to send model volume to the worker and map the new breakdown response
- update worker integration tests to match the revised request and response shapes

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd133d8ab4832c95d5aa1097b0093b