### PR TITLE
Add viewer e2e test for STL upload workflow

### DIFF
--- a/slicer-web/e2e/fixtures/sample.stl
+++ b/slicer-web/e2e/fixtures/sample.stl
@@ -1,0 +1,86 @@
+solid cube
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 0 1
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 1 1
+      vertex 0 1 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 1 1 0
+      vertex 1 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 0 0
+      vertex 0 1 0
+      vertex 1 1 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 1 0
+      vertex 1 1 1
+      vertex 1 1 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 1 0
+      vertex 0 1 1
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 1 0 1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 1
+      vertex 0 0 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 1 0 0
+      vertex 1 1 1
+      vertex 1 0 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 1 0 0
+      vertex 1 1 0
+      vertex 1 1 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 0 1
+      vertex 0 1 1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0 0 0
+      vertex 0 1 1
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid cube

--- a/slicer-web/e2e/viewer.spec.ts
+++ b/slicer-web/e2e/viewer.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 test('renders landing page with navigation', async ({ page }) => {
   await page.goto('/');
@@ -12,4 +17,21 @@ test('health endpoint responds', async ({ request }) => {
   expect(response.ok()).toBeTruthy();
   const json = await response.json();
   expect(json.status).toBe('ok');
+});
+
+test('loads viewer and computes estimate for uploaded STL', async ({ page }) => {
+  await page.goto('/viewer');
+
+  const fileInput = page.locator('input[type="file"]');
+  const sampleFile = path.resolve(__dirname, 'fixtures', 'sample.stl');
+
+  await fileInput.setInputFiles(sampleFile);
+
+  await expect(fileInput).toBeDisabled();
+  await expect(fileInput).toBeEnabled();
+
+  const summaryRegion = page.getByRole('region', { name: /estimate summary/i });
+  await expect(summaryRegion.getByRole('heading', { name: 'Print estimate' })).toBeVisible();
+  await expect(summaryRegion.getByRole('term', { name: 'Volume' })).toBeVisible();
+  await expect(summaryRegion.getByRole('term', { name: 'Mass' })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- add a lightweight ASCII STL fixture for use in Playwright scenarios
- extend the viewer E2E spec to cover uploading the sample mesh and checking estimate metrics

## Testing
- pnpm e2e *(fails: Next.js type check reports `"three-stdlib"` has no exported member named `BufferGeometryUtils`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2edfc008832ca0261ffa2c87f813