### PR TITLE
chore(ci): run pnpm commands in slicer-web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+defaults:
+  run:
+    working-directory: slicer-web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: slicer-web/pnpm-lock.yaml
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: slicer-web/.next/cache
+          key: next-cache-${{ runner.os }}-${{ hashFiles('slicer-web/pnpm-lock.yaml') }}
+          restore-keys: |
+            next-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Run unit tests
+        run: pnpm test -- --run
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: slicer-web/playwright-report
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- configure the CI workflow to run pnpm commands from the slicer-web package directory
- adjust cache and artifact paths to point to slicer-web assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd353d71a0832ca1800686f52f6f3a