### PR TITLE
Add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,21 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Release Please
+        uses: google-github-actions/release-please-action@v4
+        with:
+          command: manifest
+          release-type: node
+          config-file: slicer-web/release-please-config.json


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run release-please in manifest mode against the existing configuration
- enable push and manual triggers with write permissions so releases can be proposed automatically

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd3678252c832ca1a6021b4673124c