### PR TITLE
Add geometry worker volume integration tests

### DIFF
--- a/slicer-web/package.json
+++ b/slicer-web/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "comlink": "^4.4.1",
     "dexie": "^4.0.8",
+    "fflate": "^0.8.2",
     "jspdf": "^2.5.2",
     "next": "15.5.4",
     "next-pwa": "^5.6.0",
@@ -47,6 +48,7 @@
     "@typescript-eslint/parser": "^8.18.1",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^3.0.4",
+    "esbuild": "^0.25.10",
     "eslint": "^9.17.0",
     "eslint-config-next": "15.5.4",
     "eslint-config-prettier": "^10.1.8",

--- a/slicer-web/pnpm-lock.yaml
+++ b/slicer-web/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dexie:
         specifier: ^4.0.8
         version: 4.2.0
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       jspdf:
         specifier: ^2.5.2
         version: 2.5.2
@@ -22,7 +25,7 @@ importers:
         version: 15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-pwa:
         specifier: ^5.6.0
-        version: 5.6.0(@babel/core@7.28.4)(@types/babel__core@7.20.5)(next@15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.102.0)
+        version: 5.6.0(@babel/core@7.28.4)(@types/babel__core@7.20.5)(esbuild@0.25.10)(next@15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.102.0(esbuild@0.25.10))
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -84,6 +87,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.0.4
         version: 3.2.4(vitest@3.2.4(@types/node@20.19.18)(jiti@2.6.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.44.0)(yaml@2.8.1))
+      esbuild:
+        specifier: ^0.25.10
+        version: 0.25.10
       eslint:
         specifier: ^9.17.0
         version: 9.36.0(jiti@2.6.0)
@@ -6919,14 +6925,14 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@8.4.1(@babel/core@7.28.4)(webpack@5.102.0):
+  babel-loader@8.4.1(@babel/core@7.28.4)(webpack@5.102.0(esbuild@0.25.10)):
     dependencies:
       '@babel/core': 7.28.4
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.102.0
+      webpack: 5.102.0(esbuild@0.25.10)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.4):
     dependencies:
@@ -7059,10 +7065,10 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  clean-webpack-plugin@4.0.0(webpack@5.102.0):
+  clean-webpack-plugin@4.0.0(webpack@5.102.0(esbuild@0.25.10)):
     dependencies:
       del: 4.1.1
-      webpack: 5.102.0
+      webpack: 5.102.0(esbuild@0.25.10)
 
   cli-cursor@5.0.0:
     dependencies:
@@ -8676,14 +8682,14 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-pwa@5.6.0(@babel/core@7.28.4)(@types/babel__core@7.20.5)(next@15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.102.0):
+  next-pwa@5.6.0(@babel/core@7.28.4)(@types/babel__core@7.20.5)(esbuild@0.25.10)(next@15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(webpack@5.102.0(esbuild@0.25.10)):
     dependencies:
-      babel-loader: 8.4.1(@babel/core@7.28.4)(webpack@5.102.0)
-      clean-webpack-plugin: 4.0.0(webpack@5.102.0)
+      babel-loader: 8.4.1(@babel/core@7.28.4)(webpack@5.102.0(esbuild@0.25.10))
+      clean-webpack-plugin: 4.0.0(webpack@5.102.0(esbuild@0.25.10))
       globby: 11.1.0
       next: 15.5.4(@babel/core@7.28.4)(@playwright/test@1.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      terser-webpack-plugin: 5.3.14(webpack@5.102.0)
-      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(webpack@5.102.0)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.10)(webpack@5.102.0(esbuild@0.25.10))
+      workbox-webpack-plugin: 6.6.0(@types/babel__core@7.20.5)(webpack@5.102.0(esbuild@0.25.10))
       workbox-window: 6.6.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -9530,14 +9536,16 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.14(webpack@5.102.0):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.10)(webpack@5.102.0(esbuild@0.25.10)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.102.0
+      webpack: 5.102.0(esbuild@0.25.10)
+    optionalDependencies:
+      esbuild: 0.25.10
 
   terser@5.44.0:
     dependencies:
@@ -9873,7 +9881,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.102.0:
+  webpack@5.102.0(esbuild@0.25.10):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -9897,7 +9905,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.3
-      terser-webpack-plugin: 5.3.14(webpack@5.102.0)
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.10)(webpack@5.102.0(esbuild@0.25.10))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -10093,12 +10101,12 @@ snapshots:
 
   workbox-sw@6.6.0: {}
 
-  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(webpack@5.102.0):
+  workbox-webpack-plugin@6.6.0(@types/babel__core@7.20.5)(webpack@5.102.0(esbuild@0.25.10)):
     dependencies:
       fast-json-stable-stringify: 2.1.0
       pretty-bytes: 5.6.0
       upath: 1.2.0
-      webpack: 5.102.0
+      webpack: 5.102.0(esbuild@0.25.10)
       webpack-sources: 1.4.3
       workbox-build: 6.6.0(@types/babel__core@7.20.5)
     transitivePeerDependencies:

--- a/slicer-web/tests/stubs/three-stdlib.ts
+++ b/slicer-web/tests/stubs/three-stdlib.ts
@@ -1,0 +1,3 @@
+export { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+export { STLLoader } from 'three/examples/jsm/loaders/STLLoader.js';
+export { ThreeMFLoader } from 'three/examples/jsm/loaders/3MFLoader.js';

--- a/slicer-web/tests/unit/geometry.volume.test.ts
+++ b/slicer-web/tests/unit/geometry.volume.test.ts
@@ -1,0 +1,246 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { BoxGeometry } from 'three';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { Worker as NodeWorker } from 'node:worker_threads';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { Buffer } from 'node:buffer';
+import { createRequire } from 'node:module';
+
+import { createWorkerHandle, type WorkerHandle } from '../../lib/worker-factory';
+import type { GeometryWorkerApi } from '../../workers/geometry.worker';
+
+class VitestTextEncoder {
+  encode(input: string): Uint8Array {
+    const buffer = Buffer.from(input, 'utf-8');
+    return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  }
+}
+
+(globalThis as unknown as { TextEncoder: typeof TextEncoder }).TextEncoder =
+  VitestTextEncoder as unknown as typeof TextEncoder;
+
+const { build } = await import('esbuild');
+
+const projectRoot = process.cwd();
+const require = createRequire(import.meta.url);
+const fflateEntry = require.resolve('fflate');
+const threeStdlibStub = path.resolve(projectRoot, 'tests/stubs/three-stdlib.ts');
+const bufferGeometryLoaderPath = require.resolve('three/src/loaders/BufferGeometryLoader.js');
+const stlLoaderPath = require.resolve('three/examples/jsm/loaders/STLLoader.js');
+const threeMfLoaderPath = require.resolve('three/examples/jsm/loaders/3MFLoader.js');
+
+function resolveWorkerEntry(url: URL): string {
+  if (url.protocol === 'file:') {
+    return fileURLToPath(url);
+  }
+
+  if (url.protocol === 'http:' || url.protocol === 'https:') {
+    return path.resolve(projectRoot, `.${decodeURIComponent(url.pathname)}`);
+  }
+
+  throw new Error(`Unsupported worker URL protocol: ${url.protocol}`);
+}
+
+async function bundleWorker(entryPath: string): Promise<string> {
+  const result = await build({
+    entryPoints: [entryPath],
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'es2020',
+    sourcemap: 'inline',
+    write: false,
+    absWorkingDir: projectRoot,
+    plugins: [
+      {
+        name: 'worker-alias',
+        setup(build) {
+          build.onResolve({ filter: /^three\/addons\/loaders\/BufferGeometryLoader\.js$/ }, () => ({
+            path: bufferGeometryLoaderPath
+          }));
+          build.onResolve({ filter: /^three\/examples\/jsm\/loaders\/BufferGeometryLoader\.js$/ }, () => ({
+            path: bufferGeometryLoaderPath
+          }));
+          build.onResolve({ filter: /^three\/addons\/loaders\/STLLoader\.js$/ }, () => ({
+            path: stlLoaderPath
+          }));
+          build.onResolve({ filter: /^three\/examples\/jsm\/loaders\/STLLoader\.js$/ }, () => ({
+            path: stlLoaderPath
+          }));
+          build.onResolve({ filter: /^three\/addons\/loaders\/3MFLoader\.js$/ }, () => ({
+            path: threeMfLoaderPath
+          }));
+          build.onResolve({ filter: /^three\/examples\/jsm\/loaders\/3MFLoader\.js$/ }, () => ({
+            path: threeMfLoaderPath
+          }));
+          build.onResolve({ filter: /^three-stdlib$/ }, () => ({
+            path: threeStdlibStub
+          }));
+          build.onResolve({ filter: /^fflate$/ }, () => ({
+            path: fflateEntry
+          }));
+        }
+      }
+    ]
+  });
+
+  const prelude = `import { parentPort } from 'node:worker_threads';
+const listeners = new Map();
+const endpoint = {
+  postMessage: (data) => parentPort.postMessage(data),
+  addEventListener: (type, listener) => {
+    if (type !== 'message') {
+      return;
+    }
+    const handler = (data) => listener({ data });
+    listeners.set(listener, handler);
+    parentPort.on('message', handler);
+  },
+  removeEventListener: (type, listener) => {
+    if (type !== 'message') {
+      return;
+    }
+    const handler = listeners.get(listener);
+    if (handler) {
+      parentPort.off('message', handler);
+      listeners.delete(listener);
+    }
+  }
+};
+globalThis.self = endpoint;
+globalThis.addEventListener = endpoint.addEventListener;
+globalThis.removeEventListener = endpoint.removeEventListener;
+globalThis.postMessage = endpoint.postMessage;
+`;
+
+  return `${prelude}\n${result.outputFiles[0].text}`;
+}
+
+const workerBundles = new Map<string, string>();
+
+const geometryWorkerUrl = new URL('../../workers/geometry.worker.ts', import.meta.url);
+workerBundles.set(geometryWorkerUrl.href, await bundleWorker(resolveWorkerEntry(geometryWorkerUrl)));
+
+if (typeof globalThis.Worker === 'undefined') {
+  class VitestWorker extends NodeWorker {
+    #listeners = new Map<EventListenerOrEventListenerObject, (value: unknown) => void>();
+
+    constructor(url: string | URL, options?: ConstructorParameters<typeof NodeWorker>[1]) {
+      const resolvedUrl =
+        typeof url === 'string'
+          ? url.startsWith('file:')
+            ? new URL(url)
+            : pathToFileURL(url)
+          : url;
+
+      const outputText = workerBundles.get(resolvedUrl.href);
+
+      if (!outputText) {
+        throw new Error(`No bundled worker available for ${resolvedUrl.href}`);
+      }
+
+      const workerOptions: ConstructorParameters<typeof NodeWorker>[1] = {
+        ...(options ?? {}),
+        eval: true,
+        type: 'module'
+      };
+
+      super(outputText, workerOptions);
+    }
+
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      if (type !== 'message') {
+        return;
+      }
+      const handler: (value: unknown) => void = (value) => {
+        if (typeof listener === 'function') {
+          listener({ data: value } as MessageEvent<unknown>);
+        } else if (listener && typeof listener === 'object' && 'handleEvent' in listener) {
+          (listener.handleEvent as (event: MessageEvent<unknown>) => void)({ data: value } as MessageEvent<unknown>);
+        }
+      };
+      this.#listeners.set(listener, handler);
+      this.on('message', handler);
+    }
+
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      if (type !== 'message') {
+        return;
+      }
+      const handler = this.#listeners.get(listener);
+      if (handler) {
+        this.off('message', handler);
+        this.#listeners.delete(listener);
+      }
+    }
+  }
+
+  (globalThis as unknown as { Worker: typeof Worker }).Worker = VitestWorker as unknown as typeof Worker;
+}
+
+let workerHandle: WorkerHandle<GeometryWorkerApi> | undefined;
+
+function getGeometryWorkerHandle(): WorkerHandle<GeometryWorkerApi> {
+  if (!workerHandle) {
+    workerHandle = createWorkerHandle<GeometryWorkerApi>(
+      new URL('../../workers/geometry.worker.ts', import.meta.url)
+    );
+  }
+
+  return workerHandle;
+}
+
+afterAll(() => {
+  if (workerHandle) {
+    workerHandle.terminate();
+    workerHandle = undefined;
+  }
+});
+
+describe('geometry volume analysis', () => {
+  it('computes an accurate volume for typed array payloads', async () => {
+    const { proxy } = getGeometryWorkerHandle();
+
+    const geometry = new BoxGeometry(20, 20, 20);
+    const positionAttribute = geometry.getAttribute('position');
+    const positions = new Float32Array(positionAttribute.array as ArrayLike<number>);
+
+    const indexAttribute = geometry.getIndex();
+    const indices = indexAttribute
+      ? new Uint32Array(indexAttribute.array as ArrayLike<number>)
+      : undefined;
+
+    const result = await proxy.analyzeGeometry({
+      positions: positions.buffer,
+      indices: indices?.buffer
+    });
+
+    geometry.dispose();
+
+    const volume = result.metrics.volume.absolute;
+    const expectedVolume = 8000;
+    const tolerance = expectedVolume * 0.01;
+    expect(volume).toBeGreaterThanOrEqual(expectedVolume - tolerance);
+    expect(volume).toBeLessThanOrEqual(expectedVolume + tolerance);
+  });
+
+  it('computes positive volume for STL geometry payloads', async () => {
+    const { proxy } = getGeometryWorkerHandle();
+
+    const stlPath = path.resolve(__dirname, '../../e2e/fixtures/sample.stl');
+    const fileBuffer = await fs.readFile(stlPath);
+    const arrayBuffer = fileBuffer.buffer.slice(
+      fileBuffer.byteOffset,
+      fileBuffer.byteOffset + fileBuffer.byteLength
+    );
+
+    const result = await proxy.analyzeGeometry({
+      buffer: arrayBuffer,
+      fileName: 'sample.stl',
+      mimeType: 'model/stl'
+    });
+
+    expect(result.metrics.volume.absolute).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests verifying geometry worker volume metrics for typed arrays and STL input
- bundle the geometry worker for vitest using esbuild and polyfill worker APIs
- introduce a three-stdlib stub and required dependencies to support the worker in tests

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dfb58d2954832cafc4808d3892e491