### PR TITLE
Add upload e2e test verifying estimate metrics

### DIFF
--- a/slicer-web/e2e/upload.spec.ts
+++ b/slicer-web/e2e/upload.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SAMPLE_FILE = path.resolve(__dirname, 'fixtures', 'sample.stl');
+
+const sanitizeNumber = (value: string): number => {
+  const parsed = parseFloat(value.replace(/[^0-9.]+/g, ''));
+  return Number.isNaN(parsed) ? NaN : parsed;
+};
+
+test.describe('upload workflow', () => {
+  test('uploads a model and validates estimate values', async ({ page }) => {
+    await page.goto('/viewer');
+
+    const fileInput = page.locator('input[type="file"]');
+    await expect(fileInput).toHaveCount(1);
+
+    await fileInput.setInputFiles(SAMPLE_FILE);
+
+    await expect(fileInput).toBeDisabled();
+    await expect(fileInput).toBeEnabled();
+
+    const summaryRegion = page.getByRole('region', { name: /estimate summary/i });
+    await expect(summaryRegion.getByRole('heading', { name: 'Print estimate' })).toBeVisible();
+
+    const volumeValue = summaryRegion.locator('dt:has-text("Volume") + dd');
+    await expect(volumeValue).toBeVisible();
+    const volumeText = await volumeValue.innerText();
+    const volumeNumber = sanitizeNumber(volumeText);
+    expect(volumeNumber).toBeGreaterThan(0);
+
+    const resinCostValue = summaryRegion.locator('dt:has-text("Resin cost") + dd');
+    await expect(resinCostValue).toBeVisible();
+    const resinCostText = await resinCostValue.innerText();
+    const resinCostNumber = sanitizeNumber(resinCostText);
+    expect(resinCostNumber).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated upload Playwright spec that loads the viewer and submits the sample STL
- verify the estimate summary renders, including non-zero volume and resin cost values, and that the file input re-enables after processing

## Testing
- pnpm exec playwright test e2e/upload.spec.ts *(fails: Next.js production build missing for start:prod)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcaa1ddf0832c9d82cdde6a528765