### PR TITLE
Add G-code parsing helper and tests

### DIFF
--- a/slicer-web/lib/gcode.ts
+++ b/slicer-web/lib/gcode.ts
@@ -1,0 +1,165 @@
+export interface GcodeEstimate {
+  time_s: number;
+  filamentLen_mm: number;
+}
+
+interface Vector3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+function sanitizeLine(line: string): string {
+  let sanitized = line;
+  sanitized = sanitized.replace(/\(.*?\)/g, '');
+  const semicolonIndex = sanitized.indexOf(';');
+  if (semicolonIndex !== -1) {
+    sanitized = sanitized.slice(0, semicolonIndex);
+  }
+  return sanitized.trim();
+}
+
+function parseArgs(parts: string[]): Record<string, number> {
+  const args: Record<string, number> = {};
+
+  for (let i = 1; i < parts.length; i += 1) {
+    const token = parts[i];
+    if (!token) {
+      continue;
+    }
+
+    const letter = token[0]?.toUpperCase();
+    const value = Number.parseFloat(token.slice(1));
+    if (!letter || Number.isNaN(value)) {
+      continue;
+    }
+    args[letter] = value;
+  }
+
+  return args;
+}
+
+export function parseAndEstimate(content: string): GcodeEstimate {
+  const position: Vector3 = { x: 0, y: 0, z: 0 };
+  let extruder = 0;
+  let absolutePositioning = true;
+  let absoluteExtrusion = true;
+  let feedRateMmPerMin: number | undefined;
+
+  let time_s = 0;
+  let filamentLen_mm = 0;
+
+  const lines = content.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = sanitizeLine(rawLine);
+    if (!line) {
+      continue;
+    }
+
+    const parts = line.split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      continue;
+    }
+
+    const command = parts[0].toUpperCase();
+    const commandLetter = command[0];
+    const commandNumber = Number.parseInt(command.slice(1), 10);
+
+    if (!commandLetter || Number.isNaN(commandNumber)) {
+      continue;
+    }
+
+    const args = parseArgs(parts);
+
+    if (commandLetter === 'G') {
+      switch (commandNumber) {
+        case 90:
+          absolutePositioning = true;
+          continue;
+        case 91:
+          absolutePositioning = false;
+          continue;
+        case 92: {
+          if ('X' in args) {
+            position.x = args.X;
+          }
+          if ('Y' in args) {
+            position.y = args.Y;
+          }
+          if ('Z' in args) {
+            position.z = args.Z;
+          }
+          if ('E' in args) {
+            extruder = args.E;
+          }
+          continue;
+        }
+        default:
+          break;
+      }
+    } else if (commandLetter === 'M') {
+      if (commandNumber === 82) {
+        absoluteExtrusion = true;
+        continue;
+      }
+      if (commandNumber === 83) {
+        absoluteExtrusion = false;
+        continue;
+      }
+    }
+
+    const isMoveCommand = commandLetter === 'G' && (commandNumber === 0 || commandNumber === 1);
+    if (!isMoveCommand) {
+      continue;
+    }
+
+    if ('F' in args) {
+      const candidate = args.F;
+      feedRateMmPerMin = candidate > 0 ? candidate : undefined;
+    }
+
+    const nextPosition: Vector3 = { ...position };
+    if ('X' in args) {
+      nextPosition.x = absolutePositioning ? args.X : nextPosition.x + args.X;
+    }
+    if ('Y' in args) {
+      nextPosition.y = absolutePositioning ? args.Y : nextPosition.y + args.Y;
+    }
+    if ('Z' in args) {
+      nextPosition.z = absolutePositioning ? args.Z : nextPosition.z + args.Z;
+    }
+
+    let extrusionDelta = 0;
+    if ('E' in args) {
+      if (absoluteExtrusion) {
+        extrusionDelta = args.E - extruder;
+        extruder = args.E;
+      } else {
+        extrusionDelta = args.E;
+        extruder += args.E;
+      }
+    }
+
+    const dx = nextPosition.x - position.x;
+    const dy = nextPosition.y - position.y;
+    const dz = nextPosition.z - position.z;
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+
+    if (distance > 0 && feedRateMmPerMin && feedRateMmPerMin > 0) {
+      const feedRateMmPerSec = feedRateMmPerMin / 60;
+      if (feedRateMmPerSec > 0) {
+        time_s += distance / feedRateMmPerSec;
+      }
+    }
+
+    if (extrusionDelta > 0) {
+      filamentLen_mm += extrusionDelta;
+    }
+
+    position.x = nextPosition.x;
+    position.y = nextPosition.y;
+    position.z = nextPosition.z;
+  }
+
+  return { time_s, filamentLen_mm };
+}

--- a/slicer-web/tests/fixtures/tiny-square.gcode
+++ b/slicer-web/tests/fixtures/tiny-square.gcode
@@ -1,0 +1,20 @@
+; Tiny square test fixture
+G90 ; absolute positioning
+M82 ; absolute extrusion
+G92 E0 ; reset extruder
+
+G1 F1800 ; set feed rate to 30mm/s
+G1 X10 Y0 E0.5 ; move east and extrude
+G1 X10 Y10 E1.0 ; move north
+G1 X0 Y10 E1.5 ; move west
+G1 X0 Y0 E2.0 ; move south
+G0 X0 Y0 ; travel move without extrusion
+
+G1 X0 Y0 Z0.2 F600 ; lift Z with slower feed rate
+G0 Z0.2 ; travel only move with comment (should be ignored)
+G1 X10 Y0 E2.5 ; resume extrusion at slower speed
+G0 X0 Y0 ; travel back home
+G92 E0 ; reset extruder again
+
+G1 X0 Y0.2 E0.1 F1200 ; short extrusion after reset
+G1 X0 Y0.4 E0.0 ; extrusion decreases (should not count)

--- a/slicer-web/tests/unit/gcode.test.ts
+++ b/slicer-web/tests/unit/gcode.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseAndEstimate } from '../../lib/gcode';
+
+describe('gcode parsing helpers', () => {
+  it('estimates time and filament from the tiny square fixture', () => {
+    const fixturePath = resolve(__dirname, '../fixtures/tiny-square.gcode');
+    const gcode = readFileSync(fixturePath, 'utf-8');
+    const result = parseAndEstimate(gcode);
+
+    expect(result.filamentLen_mm).toBeCloseTo(2.6, 5);
+    expect(result.time_s).toBeCloseTo(3.3733333333, 6);
+  });
+
+  it('handles inline G92 resets and missing feed rates defensively', () => {
+    const inlineSample = `
+      g90 ; absolute positioning
+      m83 ; relative extrusion
+      g1 x1 e0.1 ; missing feed rate should not contribute to time
+      g1 f1200
+      g1 x2 e0.2 ; feed now defined
+      g92 e5 ; reset extruder to 5mm
+      g1 e-1 ; negative extrusion should not count
+    `;
+
+    const result = parseAndEstimate(inlineSample);
+
+    expect(result.filamentLen_mm).toBeCloseTo(0.3, 5);
+    expect(result.time_s).toBeCloseTo(0.05, 6);
+  });
+});


### PR DESCRIPTION
## Summary
- add a parseAndEstimate helper to compute print time and filament usage from G-code
- introduce a deterministic G-code fixture and unit tests covering comments, feed rates, and G92 resets

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dfd7b12d3c832c846a8604691ef07f