### PR TITLE
Add G-code override handling for viewer estimates

### DIFF
--- a/slicer-web/modules/store/index.ts
+++ b/slicer-web/modules/store/index.ts
@@ -2,7 +2,12 @@
 
 import { create } from 'zustand';
 import { BufferGeometry, Float32BufferAttribute, Uint32BufferAttribute, Vector3 } from 'three';
-import type { EstimateParameters, EstimateSummary, LayerEstimate } from '../estimate';
+import type {
+  EstimateBreakdown,
+  EstimateParameters,
+  EstimateSummary,
+  LayerEstimate
+} from '../estimate';
 import { DEFAULT_PARAMETERS } from '../estimate';
 import {
   computeEstimate,
@@ -13,6 +18,14 @@ import {
   type GeometryLayerSummary,
   type GeometryMetrics
 } from '../../lib/compute';
+import { parseAndEstimate } from '../../lib/gcode';
+
+export interface GcodeOverrideState {
+  fileName: string;
+  time_s: number;
+  filamentLen_mm: number;
+  loadedAt: number;
+}
 
 interface GeometryPayload {
   positions: Float32Array;
@@ -32,6 +45,11 @@ export interface ViewerStoreState {
   geometrySource?: ArrayBuffer | File;
   geometryMetrics?: GeometryMetrics;
   geometryCenter?: Vector3;
+  estimateBreakdown?: EstimateBreakdown;
+  effectiveBreakdown?: EstimateBreakdown;
+  gcodeOverride?: GcodeOverrideState;
+  gcodeLoading: boolean;
+  gcodeError?: string;
 }
 
 export interface ViewerStoreActions {
@@ -44,6 +62,8 @@ export interface ViewerStoreActions {
   ) => Promise<void>;
   setParameters: (parameters: Partial<EstimateParameters>) => Promise<void>;
   recompute: () => Promise<void>;
+  loadGcode: (file: File) => Promise<void>;
+  clearGcodeOverride: () => void;
   reset: () => void;
   disposeWorkers: () => void;
 }
@@ -57,6 +77,11 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
   geometrySource: undefined,
   geometryMetrics: undefined,
   geometryCenter: undefined,
+  estimateBreakdown: undefined,
+  effectiveBreakdown: undefined,
+  gcodeOverride: undefined,
+  gcodeLoading: false,
+  gcodeError: undefined,
 
   async loadFile(file: File) {
     set({ loading: true, error: undefined });
@@ -125,7 +150,12 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       geometryCenter: centerVector,
       geometrySource: source,
       layers: [],
-      summary: undefined
+      summary: undefined,
+      estimateBreakdown: undefined,
+      effectiveBreakdown: undefined,
+      gcodeOverride: undefined,
+      gcodeLoading: false,
+      gcodeError: undefined
     });
     await get().recompute();
   },
@@ -141,7 +171,12 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
   async recompute() {
     const payload = get().geometryPayload;
     if (!payload) {
-      set({ layers: [], summary: undefined });
+      set({
+        layers: [],
+        summary: undefined,
+        estimateBreakdown: undefined,
+        effectiveBreakdown: undefined
+      });
       return;
     }
 
@@ -179,19 +214,141 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
         }))
       }));
 
-      const summary: EstimateSummary = {
-        layers,
-        volume: estimateResponse.breakdown.volumeModel_mm3,
-        mass: estimateResponse.breakdown.mass_g,
-        resinCost: estimateResponse.breakdown.costs.total,
-        durationMinutes: estimateResponse.breakdown.time_s / 60
+      const baseBreakdown = estimateResponse.breakdown;
+      const override = get().gcodeOverride;
+      const effectiveBreakdown: EstimateBreakdown = {
+        ...baseBreakdown,
+        costs: { ...baseBreakdown.costs },
+        params: baseBreakdown.params
       };
 
-      set({ layers, summary });
+      if (override) {
+        effectiveBreakdown.time_s = override.time_s;
+        effectiveBreakdown.filamentLen_mm = override.filamentLen_mm;
+      }
+
+      const summary: EstimateSummary = {
+        layers,
+        volume: effectiveBreakdown.volumeModel_mm3,
+        mass: effectiveBreakdown.mass_g,
+        resinCost: effectiveBreakdown.costs.total,
+        durationMinutes: effectiveBreakdown.time_s / 60
+      };
+
+      set({
+        layers,
+        summary,
+        estimateBreakdown: baseBreakdown,
+        effectiveBreakdown
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       set({ error: message });
     }
+  },
+
+  async loadGcode(file: File) {
+    set({ gcodeLoading: true, gcodeError: undefined });
+
+    try {
+      const fileName = file.name;
+      const lowerName = fileName.toLowerCase();
+      const isValidExtension =
+        lowerName.endsWith('.gcode') || lowerName.endsWith('.gco') || lowerName.endsWith('.g');
+      const isValidMime =
+        !file.type ||
+        file.type === 'text/plain' ||
+        file.type === 'application/octet-stream' ||
+        file.type === 'application/x-gcode';
+
+      if (!isValidExtension && !isValidMime) {
+        throw new Error('Selecione um arquivo G-code válido.');
+      }
+
+      let content: string;
+      if (typeof file.text === 'function') {
+        content = await file.text();
+      } else if (typeof file.arrayBuffer === 'function') {
+        const buffer = await file.arrayBuffer();
+        content = new TextDecoder().decode(buffer);
+      } else {
+        throw new Error('Não foi possível ler o conteúdo do arquivo G-code.');
+      }
+      const estimate = parseAndEstimate(content);
+
+      const override: GcodeOverrideState = {
+        fileName,
+        time_s: estimate.time_s,
+        filamentLen_mm: estimate.filamentLen_mm,
+        loadedAt: Date.now()
+      };
+
+      set((state) => {
+        const summary = state.summary
+          ? {
+              ...state.summary,
+              durationMinutes: estimate.time_s / 60
+            }
+          : state.summary;
+
+        const effectiveBreakdown = state.estimateBreakdown
+          ? {
+              ...state.estimateBreakdown,
+              costs: { ...state.estimateBreakdown.costs },
+              params: state.estimateBreakdown.params,
+              time_s: override.time_s,
+              filamentLen_mm: override.filamentLen_mm
+            }
+          : state.effectiveBreakdown
+          ? {
+              ...state.effectiveBreakdown,
+              costs: { ...state.effectiveBreakdown.costs },
+              params: state.effectiveBreakdown.params,
+              time_s: override.time_s,
+              filamentLen_mm: override.filamentLen_mm
+            }
+          : undefined;
+
+        return {
+          gcodeOverride: override,
+          gcodeLoading: false,
+          gcodeError: undefined,
+          summary,
+          effectiveBreakdown
+        };
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Falha ao carregar G-code.';
+      set({ gcodeLoading: false, gcodeError: message });
+    }
+  },
+
+  clearGcodeOverride() {
+    set((state) => {
+      const summary =
+        state.summary && state.estimateBreakdown
+          ? {
+              ...state.summary,
+              durationMinutes: state.estimateBreakdown.time_s / 60
+            }
+          : state.summary;
+
+      const effectiveBreakdown = state.estimateBreakdown
+        ? {
+            ...state.estimateBreakdown,
+            costs: { ...state.estimateBreakdown.costs },
+            params: state.estimateBreakdown.params
+          }
+        : undefined;
+
+      return {
+        gcodeOverride: undefined,
+        gcodeLoading: false,
+        gcodeError: undefined,
+        summary,
+        effectiveBreakdown
+      };
+    });
   },
 
   reset() {
@@ -203,7 +360,12 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       geometryPayload: undefined,
       geometrySource: undefined,
       geometryMetrics: undefined,
-      geometryCenter: undefined
+      geometryCenter: undefined,
+      estimateBreakdown: undefined,
+      effectiveBreakdown: undefined,
+      gcodeOverride: undefined,
+      gcodeLoading: false,
+      gcodeError: undefined
     });
   },
 

--- a/slicer-web/tests/unit/paramsForm.helper.test.ts
+++ b/slicer-web/tests/unit/paramsForm.helper.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_PRINT_PARAMS, type EstimateBreakdown } from '../../lib/estimate';
+import { mergeBreakdownWithOverride } from '../../components/ParamsForm';
+
+describe('mergeBreakdownWithOverride', () => {
+  it('applies override values without mutating the base breakdown', () => {
+    const base: EstimateBreakdown = {
+      volumeModel_mm3: 123,
+      extrudedVolume_mm3: 150,
+      mass_g: 20,
+      filamentLen_mm: 45,
+      time_s: 300,
+      costs: {
+        filament: 10,
+        energy: 1,
+        maintenance: 2,
+        margin: 3,
+        total: 16
+      },
+      params: DEFAULT_PRINT_PARAMS
+    };
+
+    const snapshot = JSON.parse(JSON.stringify(base));
+    const override = { time_s: 900, filamentLen_mm: 99 };
+
+    const merged = mergeBreakdownWithOverride(base, override);
+
+    expect(merged).not.toBeNull();
+    expect(merged).not.toBe(base);
+    expect(merged?.time_s).toBe(900);
+    expect(merged?.filamentLen_mm).toBe(99);
+    expect(base).toEqual(snapshot);
+  });
+
+  it('returns a cloned copy when no override is provided', () => {
+    const base: EstimateBreakdown = {
+      volumeModel_mm3: 10,
+      extrudedVolume_mm3: 12,
+      mass_g: 3,
+      filamentLen_mm: 4,
+      time_s: 120,
+      costs: {
+        filament: 1,
+        energy: 0.5,
+        maintenance: 0.25,
+        margin: 0.1,
+        total: 1.85
+      },
+      params: DEFAULT_PRINT_PARAMS
+    };
+
+    const merged = mergeBreakdownWithOverride(base, null);
+
+    expect(merged).not.toBeNull();
+    expect(merged).not.toBe(base);
+    expect(merged).toEqual(base);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the viewer store with G-code override state, actions, and recompute integration so summaries and breakdowns stay in sync
- refactor ParamsForm to reuse worker results, merge override data via a helper, and surface parsing errors from the store
- add unit coverage for the new store override flow and the ParamsForm merge helper

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dfda720730832cb10da00855d53cc7