### PR TITLE
Add gated G-code override controls to estimates

### DIFF
--- a/slicer-web/README.md
+++ b/slicer-web/README.md
@@ -51,6 +51,13 @@ pnpm dev
 The app is available at [http://localhost:3000](http://localhost:3000). Upload a mesh to the
 viewer, explore generated layers, and export reports.
 
+### Environment configuration
+
+Set `NEXT_PUBLIC_ENABLE_GCODE_UPLOAD=true` to expose an experimental control on the estimate page
+that accepts `.gcode` files. When active, uploaded G-code replaces the heuristic print duration and
+filament usage values derived from slicing parameters. Clearing the override restores the default
+heuristic estimate. Omit or set the flag to `false` to keep the original behaviour.
+
 ## Available commands
 
 | Command              | Description                                         |

--- a/slicer-web/components/EstimateSummary.tsx
+++ b/slicer-web/components/EstimateSummary.tsx
@@ -12,6 +12,7 @@ import { useViewerStore } from '../modules/store';
 export function EstimateSummary() {
   const summary = useViewerStore((state) => state.summary);
   const fileName = useViewerStore((state) => state.fileName) ?? 'slicer-report';
+  const gcodeOverride = useViewerStore((state) => state.gcodeOverride);
 
   const metrics = useMemo(() => {
     if (!summary) {
@@ -57,7 +58,11 @@ export function EstimateSummary() {
       <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <h2 style={{ margin: 0 }}>Print estimate</h2>
-          <p style={{ margin: 0, color: '#94a3b8' }}>Computed using adaptive slicing heuristics.</p>
+          <p style={{ margin: 0, color: '#94a3b8' }}>
+            {gcodeOverride
+              ? 'Timing derived from uploaded G-code.'
+              : 'Computed using adaptive slicing heuristics.'}
+          </p>
         </div>
         <div style={{ display: 'flex', gap: '0.75rem' }}>
           <button

--- a/slicer-web/lib/config.ts
+++ b/slicer-web/lib/config.ts
@@ -3,5 +3,6 @@ export const DEFAULT_SLICE_THICKNESS = 0.05;
 
 export const FEATURE_FLAGS = {
   enableWorkers: typeof window !== 'undefined',
-  debugLogging: process.env.NEXT_PUBLIC_DEBUG_LOGGING === 'true'
+  debugLogging: process.env.NEXT_PUBLIC_DEBUG_LOGGING === 'true',
+  enableGcodeUpload: process.env.NEXT_PUBLIC_ENABLE_GCODE_UPLOAD === 'true'
 } as const;


### PR DESCRIPTION
## Summary
- add a NEXT_PUBLIC_ENABLE_GCODE_UPLOAD feature flag to toggle G-code upload support
- extend the estimate results card with gated upload controls, override messaging, and copy/export awareness
- surface G-code timing context in the estimate summary header and document the environment flag

## Testing
- pnpm dev
- NEXT_PUBLIC_ENABLE_GCODE_UPLOAD=true pnpm dev
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dffb7c2510832c9157f63799ab9d32