### PR TITLE
Preserve geometry buffers across worker transfers

### DIFF
--- a/slicer-web/tests/unit/store.worker.test.ts
+++ b/slicer-web/tests/unit/store.worker.test.ts
@@ -64,7 +64,9 @@ describe('useViewerStore worker integration', () => {
     const positions = new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]);
     mocks.computeGeometryMock.mockResolvedValue({
       positions,
+      positionsBuffer: positions.buffer,
       indices: undefined,
+      indicesBuffer: undefined,
       metrics: {
         boundingBox: { min: [-0.5, -0.5, -0.0], max: [0.5, 0.5, 0.0] },
         size: [1, 1, 0],
@@ -73,7 +75,7 @@ describe('useViewerStore worker integration', () => {
         center: [0, 0, 0]
       }
     });
-    mocks.computeGeometryLayersMock.mockResolvedValue({
+    mocks.computeGeometryLayersMock.mockImplementation(async (request) => ({
       layers: [
         {
           elevation: 0,
@@ -89,8 +91,12 @@ describe('useViewerStore worker integration', () => {
           ]
         }
       ],
-      volume: 1
-    });
+      volume: 1,
+      positions: request.positions,
+      positionsBuffer: request.positionsBuffer ?? request.positions.buffer,
+      indices: request.indices,
+      indicesBuffer: request.indicesBuffer ?? request.indices?.buffer
+    }));
     mocks.computeEstimateMock.mockResolvedValue({
       breakdown: {
         volumeModel_mm3: 1,
@@ -121,6 +127,7 @@ describe('useViewerStore worker integration', () => {
     expect(mocks.computeGeometryLayersMock).toHaveBeenCalledTimes(1);
     const [geometryRequest] = mocks.computeGeometryLayersMock.mock.calls[0];
     expect(geometryRequest.positions).toBeInstanceOf(Float32Array);
+    expect(geometryRequest.positionsBuffer).toBeInstanceOf(ArrayBuffer);
     expect(mocks.computeEstimateMock).toHaveBeenCalledTimes(1);
     expect(mocks.computeEstimateMock).toHaveBeenCalledWith(0.5);
 


### PR DESCRIPTION
## Summary
- retain raw ArrayBuffer handles alongside typed geometry arrays in the viewer store and refresh them after worker recomputes
- send original buffers to the geometry worker without cloning and rebuild typed views from the returned buffers
- update the geometry worker to operate directly on transferred buffers, transfer them back to the main thread, and adjust unit tests accordingly

## Testing
- pnpm vitest run store.worker

------
https://chatgpt.com/codex/tasks/task_e_68e00011cd04832c8bb07469ce2fbcb0