### PR TITLE
feat: guard oversized mesh uploads

### DIFF
--- a/slicer-web/components/FileDrop.tsx
+++ b/slicer-web/components/FileDrop.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { useViewerStore } from '../modules/store';
+import { FILE_TOO_LARGE_ERROR, MAX_FILE_SIZE_BYTES, useViewerStore } from '../modules/store';
 
 const SUPPORTED_EXTENSIONS = ['.stl', '.3mf'];
 const SUPPORTED_MIME_TYPES = new Set([
@@ -39,6 +39,12 @@ export function FileDrop() {
   const handleFile = useCallback(
     async (file: File | undefined) => {
       if (!file) {
+        return;
+      }
+
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        useViewerStore.setState({ error: FILE_TOO_LARGE_ERROR, loading: false });
+        resetInput();
         return;
       }
 

--- a/slicer-web/modules/store/index.ts
+++ b/slicer-web/modules/store/index.ts
@@ -75,6 +75,9 @@ export type ViewerStore = ViewerStoreState & ViewerStoreActions;
 
 const recomputeScheduler = createIdleScheduler();
 
+export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
+export const FILE_TOO_LARGE_ERROR = 'File is too large. Please upload a file smaller than 50 MB.';
+
 export const useViewerStore = create<ViewerStore>((set, get) => ({
   layers: [],
   parameters: DEFAULT_PARAMETERS,
@@ -89,6 +92,11 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
   gcodeError: undefined,
 
   async loadFile(file: File) {
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      set({ error: FILE_TOO_LARGE_ERROR, loading: false });
+      return;
+    }
+
     set({ loading: true, error: undefined });
     try {
       const response = await computeGeometry(file);

--- a/slicer-web/tests/unit/components/FileDrop.test.ts
+++ b/slicer-web/tests/unit/components/FileDrop.test.ts
@@ -1,0 +1,72 @@
+import { createElement } from 'react';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FileDrop } from '../../../components/FileDrop';
+import {
+  FILE_TOO_LARGE_ERROR,
+  MAX_FILE_SIZE_BYTES,
+  type ViewerStore,
+  useViewerStore
+} from '../../../modules/store';
+
+describe('FileDrop', () => {
+  const originalLoadFile = useViewerStore.getState().loadFile;
+  const originalSetState = useViewerStore.setState;
+  const loadFileMock = vi.fn<
+    Parameters<ViewerStore['loadFile']>,
+    ReturnType<ViewerStore['loadFile']>
+  >().mockResolvedValue(undefined);
+
+  beforeAll(() => {
+    useViewerStore.setState = ((...args) => {
+      act(() => {
+        originalSetState(...args);
+      });
+    }) as typeof useViewerStore.setState;
+  });
+
+  beforeEach(() => {
+    loadFileMock.mockClear();
+    useViewerStore.setState({
+      loadFile: loadFileMock,
+      error: undefined,
+      loading: false
+    });
+  });
+
+  afterAll(() => {
+    useViewerStore.setState = originalSetState;
+  });
+
+  afterEach(() => {
+    useViewerStore.setState({
+      loadFile: originalLoadFile,
+      error: undefined,
+      loading: false
+    });
+  });
+
+  it('surfaces an error and resets the input when the file is too large', async () => {
+    const user = userEvent.setup();
+    render(createElement(FileDrop));
+
+    const input = screen.getByLabelText(/choose file/i) as HTMLInputElement;
+    const file = new File(['dummy'], 'large.stl', { type: 'model/stl' });
+    Object.defineProperty(file, 'size', {
+      get: () => MAX_FILE_SIZE_BYTES + 1
+    });
+
+    await act(async () => {
+      await user.upload(input, file);
+    });
+
+    expect(screen.getByText(FILE_TOO_LARGE_ERROR)).toBeInTheDocument();
+
+    expect(useViewerStore.getState().error).toBe(FILE_TOO_LARGE_ERROR);
+    expect(useViewerStore.getState().loading).toBe(false);
+    expect(loadFileMock).not.toHaveBeenCalled();
+    expect(input.value).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent oversized mesh uploads in the viewer store and reuse the size limit constant
- surface a descriptive error and reset the input when large files are dropped through the FileDrop component
- add unit coverage for the new guards to ensure oversized files are rejected with the expected messaging

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e00f5c4c78832ca389127c26e0db93