### PR TITLE
Add error boundary for viewer page

### DIFF
--- a/slicer-web/app/viewer/page.tsx
+++ b/slicer-web/app/viewer/page.tsx
@@ -1,12 +1,15 @@
 import { EstimateSummary } from '../../components/EstimateSummary';
 import { FileDrop } from '../../components/FileDrop';
 import { ModelViewer } from '../../components/ModelViewer';
+import { ViewerErrorBoundary } from '../../components/ViewerErrorBoundary';
 
 export default function ViewerPage() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
       <FileDrop />
-      <ModelViewer />
+      <ViewerErrorBoundary>
+        <ModelViewer />
+      </ViewerErrorBoundary>
       <EstimateSummary />
     </div>
   );

--- a/slicer-web/components/ViewerErrorBoundary.tsx
+++ b/slicer-web/components/ViewerErrorBoundary.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+import { useViewerStore } from '../modules/store';
+
+interface ViewerErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ViewerErrorBoundaryState {
+  hasError: boolean;
+  errorMessage?: string;
+}
+
+export class ViewerErrorBoundary extends Component<
+  ViewerErrorBoundaryProps,
+  ViewerErrorBoundaryState
+> {
+  constructor(props: ViewerErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown): ViewerErrorBoundaryState {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : 'An unexpected error occurred.';
+
+    return { hasError: true, errorMessage: message };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('ViewerErrorBoundary caught an error', error, info);
+    }
+  }
+
+  private handleReset = () => {
+    useViewerStore.getState().reset();
+    this.setState({ hasError: false, errorMessage: undefined });
+  };
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.75rem',
+            padding: '1.5rem',
+            borderRadius: '0.75rem',
+            backgroundColor: 'rgba(30, 41, 59, 0.6)',
+            border: '1px solid rgba(148, 163, 184, 0.4)'
+          }}
+        >
+          <div>
+            <h2 style={{ fontSize: '1.125rem', fontWeight: 600, margin: 0 }}>
+              Viewer failed to load
+            </h2>
+            <p style={{ margin: '0.25rem 0 0', color: 'rgba(226, 232, 240, 0.9)' }}>
+              {this.state.errorMessage}
+            </p>
+            <p style={{ margin: '0.5rem 0 0', color: 'rgba(148, 163, 184, 0.9)' }}>
+              Try resetting the viewer and reloading your model.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={this.handleReset}
+            style={{
+              alignSelf: 'flex-start',
+              padding: '0.5rem 1rem',
+              borderRadius: '9999px',
+              border: 'none',
+              backgroundColor: '#38bdf8',
+              color: '#0f172a',
+              fontWeight: 600,
+              cursor: 'pointer'
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ViewerErrorBoundary;

--- a/slicer-web/tests/unit/components/ViewerErrorBoundary.test.tsx
+++ b/slicer-web/tests/unit/components/ViewerErrorBoundary.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ViewerPage from '../../../app/viewer/page';
+import { useViewerStore } from '../../../modules/store';
+
+let shouldThrow = false;
+
+vi.mock('../../../components/ModelViewer', async () => {
+  const React = await import('react');
+
+  const MockModelViewer = () => {
+    if (shouldThrow) {
+      shouldThrow = false;
+      throw new Error('Mock viewer failure');
+    }
+
+    return React.createElement('div', { 'data-testid': 'mock-viewer' }, 'Mock Viewer Ready');
+  };
+
+  return { ModelViewer: MockModelViewer };
+});
+
+describe('ViewerErrorBoundary', () => {
+  beforeEach(() => {
+    shouldThrow = true;
+    useViewerStore.setState({
+      geometry: { mock: true } as never,
+      layers: [{ id: 'layer-1' } as never]
+    });
+  });
+
+  afterEach(() => {
+    useViewerStore.getState().reset();
+  });
+
+  it('renders the mocked ModelViewer after recovering from an error', async () => {
+    render(<ViewerPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Mock viewer failure');
+
+    const resetButton = screen.getByRole('button', { name: /try again/i });
+    fireEvent.click(resetButton);
+
+    expect(useViewerStore.getState().geometry).toBeUndefined();
+    expect(useViewerStore.getState().layers).toEqual([]);
+
+    expect(await screen.findByTestId('mock-viewer')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a client-side ViewerErrorBoundary that resets the viewer store and shows recovery UI when rendering fails
- wrap ModelViewer with the new boundary on the viewer page so errors are caught without converting the page to a client component
- verify recovery behaviour with a unit test that mocks ModelViewer to throw and ensures the reset action restores the viewer

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e014397730832ca3d92a413b40942e