### PR TITLE
feat: validate print estimates via worker

### DIFF
--- a/slicer-web/components/ParamsForm.tsx
+++ b/slicer-web/components/ParamsForm.tsx
@@ -264,9 +264,9 @@ export function ParamsForm({
           filamentDiameter_mm: data.filamentDiameter_mm,
         };
 
-        const response = await worker.proxy.estimate({ volumeModel_mm3, params });
+        const breakdown = await worker.proxy.estimateAll(volumeModel_mm3, params);
         if (!cancelled) {
-          setWorkerBreakdown(response.breakdown);
+          setWorkerBreakdown(breakdown);
         }
       } catch (error) {
         if (!cancelled) {

--- a/slicer-web/lib/compute.ts
+++ b/slicer-web/lib/compute.ts
@@ -2,9 +2,9 @@ import { transfer } from 'comlink';
 
 import { createWorkerHandle, type WorkerHandle } from './worker-factory';
 
-import type { PrintParams } from './estimate';
+import type { EstimateBreakdown, PrintParams } from './estimate';
 import type { EstimateParameters } from '../modules/estimate';
-import type { EstimateWorkerApi, EstimateWorkerResponse } from '../workers/estimate.worker';
+import type { EstimateWorkerApi } from '../workers/estimate.worker';
 import type { GeometryMetrics, GeometryWorkerApi } from '../workers/geometry.worker';
 
 let geometryHandle: WorkerHandle<GeometryWorkerApi> | undefined;
@@ -143,9 +143,9 @@ export async function computeGeometryLayers(
 export async function computeEstimate(
   volumeModel_mm3: number,
   params?: Partial<PrintParams>,
-): Promise<EstimateWorkerResponse> {
+): Promise<EstimateBreakdown> {
   const handle = getEstimateWorkerHandle();
-  return handle.proxy.estimate({ volumeModel_mm3, params });
+  return handle.proxy.estimateAll(volumeModel_mm3, params);
 }
 
 export function releaseGeometryCompute(): void {

--- a/slicer-web/lib/estimate.ts
+++ b/slicer-web/lib/estimate.ts
@@ -1,28 +1,36 @@
+import { z } from 'zod';
+
 export const MATERIAL_DENSITIES = {
   PLA: 1.24,
   PETG: 1.27,
   ABS: 1.04,
+  TPU: 1.21,
+  NYLON: 1.14,
 } as const;
 
 export type Material = keyof typeof MATERIAL_DENSITIES;
 
-export interface PrintParams {
-  material: Material;
-  infill: number;
-  wallFactor: number;
-  topBottomFactor: number;
-  mvf: number;
-  targetFlow_mm3_s: number;
-  overhead: number;
-  pricePerKg: number;
-  powerW: number;
-  kwhPrice: number;
-  maintPerHour: number;
-  margin: number;
-  filamentDiameter_mm: number;
-}
+const MATERIAL_ENUM = z.enum(Object.keys(MATERIAL_DENSITIES) as [Material, ...Material[]]);
 
-export const DEFAULT_PRINT_PARAMS: PrintParams = {
+export const PrintParamsSchema = z.object({
+  material: MATERIAL_ENUM,
+  infill: z.number().min(0).max(1),
+  wallFactor: z.number().min(0).max(1),
+  topBottomFactor: z.number().min(0).max(1),
+  mvf: z.number().positive(),
+  targetFlow_mm3_s: z.number().positive(),
+  overhead: z.number().min(0).max(1),
+  pricePerKg: z.number().positive(),
+  powerW: z.number().positive(),
+  kwhPrice: z.number().min(0),
+  maintPerHour: z.number().min(0),
+  margin: z.number().min(0).max(1),
+  filamentDiameter_mm: z.number().positive(),
+});
+
+export type PrintParams = z.infer<typeof PrintParamsSchema>;
+
+const DEFAULT_PRINT_PARAMS_RAW: PrintParams = {
   material: 'PLA',
   infill: 0.2,
   wallFactor: 0.25,
@@ -37,6 +45,8 @@ export const DEFAULT_PRINT_PARAMS: PrintParams = {
   margin: 0.2,
   filamentDiameter_mm: 1.75,
 };
+
+export const DEFAULT_PRINT_PARAMS: PrintParams = PrintParamsSchema.parse(DEFAULT_PRINT_PARAMS_RAW);
 
 export interface EstimateBreakdown {
   volumeModel_mm3: number;
@@ -58,17 +68,20 @@ export function estimateAll(
   volumeModel_mm3: number,
   params: Partial<PrintParams> = {},
 ): EstimateBreakdown {
-  const normalized: PrintParams = {
-    ...DEFAULT_PRINT_PARAMS,
-    ...params,
-    material: (params.material ?? DEFAULT_PRINT_PARAMS.material).toUpperCase() as Material,
-  };
+  const materialCandidate = (params.material ?? DEFAULT_PRINT_PARAMS.material) as string;
+  const normalizedMaterial = materialCandidate.toUpperCase() as Material;
 
-  const density = MATERIAL_DENSITIES[normalized.material];
-  if (!density) {
-    throw new Error(`Unsupported material: ${normalized.material}`);
+  if (!(normalizedMaterial in MATERIAL_DENSITIES)) {
+    throw new Error(`Unsupported material: ${materialCandidate}`);
   }
 
+  const normalized = PrintParamsSchema.parse({
+    ...DEFAULT_PRINT_PARAMS,
+    ...params,
+    material: normalizedMaterial,
+  });
+
+  const density = MATERIAL_DENSITIES[normalized.material];
   const volumeFactors = normalized.infill + normalized.wallFactor + normalized.topBottomFactor;
   const extrudedVolume_mm3 = Math.max(0, volumeModel_mm3 * volumeFactors);
   const volumeExtruded_cm3 = extrudedVolume_mm3 / 1000;

--- a/slicer-web/modules/store/index.ts
+++ b/slicer-web/modules/store/index.ts
@@ -221,7 +221,7 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       const parameters = get().parameters;
 
       const metricsVolume = payload.metrics?.volume.absolute;
-      const estimateResponsePromise =
+      const estimateBreakdownPromise =
         metricsVolume !== undefined ? computeEstimate(metricsVolume) : undefined;
 
       const {
@@ -252,9 +252,9 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       }
 
       const volumeModel_mm3 = metricsVolume ?? volume;
-      const estimateResponse =
-        estimateResponsePromise !== undefined
-          ? await estimateResponsePromise
+      const baseBreakdown =
+        estimateBreakdownPromise !== undefined
+          ? await estimateBreakdownPromise
           : await computeEstimate(volumeModel_mm3);
 
       const layers: LayerEstimate[] = rawLayers.map((layer: GeometryLayerSummary) => ({
@@ -269,7 +269,6 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
         })),
       }));
 
-      const baseBreakdown = estimateResponse.breakdown;
       const override = get().gcodeOverride;
       const effectiveBreakdown: EstimateBreakdown = {
         ...baseBreakdown,

--- a/slicer-web/tests/unit/store.worker.test.ts
+++ b/slicer-web/tests/unit/store.worker.test.ts
@@ -98,21 +98,19 @@ describe('useViewerStore worker integration', () => {
       indicesBuffer: request.indicesBuffer ?? request.indices?.buffer,
     }));
     mocks.computeEstimateMock.mockResolvedValue({
-      breakdown: {
-        volumeModel_mm3: 1,
-        extrudedVolume_mm3: 1.5,
-        mass_g: 2,
-        filamentLen_mm: 3,
-        time_s: 120,
-        costs: {
-          filament: 1,
-          energy: 0.5,
-          maintenance: 0.25,
-          margin: 0.1,
-          total: 1.85,
-        },
-        params: DEFAULT_PRINT_PARAMS,
+      volumeModel_mm3: 1,
+      extrudedVolume_mm3: 1.5,
+      mass_g: 2,
+      filamentLen_mm: 3,
+      time_s: 120,
+      costs: {
+        filament: 1,
+        energy: 0.5,
+        maintenance: 0.25,
+        margin: 0.1,
+        total: 1.85,
       },
+      params: DEFAULT_PRINT_PARAMS,
     });
 
     const fileBuffer = new ArrayBuffer(8);
@@ -219,21 +217,19 @@ describe('useViewerStore worker integration', () => {
       });
 
       mocks.computeEstimateMock.mockResolvedValue({
-        breakdown: {
-          volumeModel_mm3: 1,
-          extrudedVolume_mm3: 1.5,
-          mass_g: 2,
-          filamentLen_mm: 3,
-          time_s: 120,
-          costs: {
-            filament: 1,
-            energy: 0.5,
-            maintenance: 0.25,
-            margin: 0.1,
-            total: 1.85,
-          },
-          params: DEFAULT_PRINT_PARAMS,
+        volumeModel_mm3: 1,
+        extrudedVolume_mm3: 1.5,
+        mass_g: 2,
+        filamentLen_mm: 3,
+        time_s: 120,
+        costs: {
+          filament: 1,
+          energy: 0.5,
+          maintenance: 0.25,
+          margin: 0.1,
+          total: 1.85,
         },
+        params: DEFAULT_PRINT_PARAMS,
       });
 
       useViewerStore.setState({

--- a/slicer-web/workers/estimate.worker.ts
+++ b/slicer-web/workers/estimate.worker.ts
@@ -1,23 +1,15 @@
 import { expose } from 'comlink';
 
-import { estimateAll, type EstimateBreakdown, type PrintParams } from '../lib/estimate';
+import { estimateAll as estimateAllFromLib, type EstimateBreakdown, type PrintParams } from '../lib/estimate';
 
-export interface EstimateWorkerRequest {
-  volumeModel_mm3: number;
-  params?: Partial<PrintParams>;
+export interface EstimateWorkerApi {
+  estimateAll(volumeModel_mm3: number, params?: Partial<PrintParams>): EstimateBreakdown;
 }
 
-export interface EstimateWorkerResponse {
-  breakdown: EstimateBreakdown;
-}
-
-const api = {
-  estimate({ volumeModel_mm3, params }: EstimateWorkerRequest): EstimateWorkerResponse {
-    const breakdown = estimateAll(volumeModel_mm3, params);
-    return { breakdown };
+const api: EstimateWorkerApi = {
+  estimateAll(volumeModel_mm3, params) {
+    return estimateAllFromLib(volumeModel_mm3, params);
   },
 };
-
-export type EstimateWorkerApi = typeof api;
 
 expose(api);


### PR DESCRIPTION
## Summary
- add schema validation for print parameters and extend supported material densities
- expose the estimateAll helper directly through the estimate worker and update callers
- align the params form, store integration, and tests with the new breakdown response

## Testing
- pnpm test -- tests/unit/fdm-estimate.test.ts tests/unit/estimate.engine.test.ts tests/unit/estimate.test.ts *(fails: Worker is not defined in test env; missing mergeBufferGeometries stub)*

------
https://chatgpt.com/codex/tasks/task_e_68e4033f98d8832caf670e50761f95c8