### PR TITLE
chore: enforce commit workflow

### DIFF
--- a/slicer-web/.husky/commit-msg
+++ b/slicer-web/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm commitlint --edit "$1"
+pnpm exec commitlint --edit "$1"

--- a/slicer-web/.husky/pre-commit
+++ b/slicer-web/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-pnpm lint-staged
+pnpm exec lint-staged

--- a/slicer-web/package.json
+++ b/slicer-web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "pnpm exec next lint && pnpm exec prettier -c \"{app,components,lib,modules,workers}/**/*.{ts,tsx}\" \"tests/**/*.ts?(x)\" \"styles/**/*.css\"",
+    "lint:staged": "pnpm exec lint-staged",
     "format": "pnpm exec prettier --write \"{app,components,lib,modules,workers}/**/*.{ts,tsx}\" \"tests/**/*.ts?(x)\" \"styles/**/*.css\"",
     "typecheck": "pnpm exec tsc --project tsconfig.app.json --noEmit",
     "test": "pnpm exec vitest run",
@@ -14,6 +15,7 @@
     "e2e": "pnpm exec playwright test",
     "coverage": "pnpm exec vitest run --coverage",
     "prepare": "husky",
+    "commitlint": "pnpm exec commitlint",
     "release": "release-please release"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- ensure Husky hooks invoke lint-staged and commitlint through pnpm exec for consistent tooling resolution
- add helper scripts for running lint-staged and commitlint from package.json

## Testing
- pnpm run lint:staged

------
https://chatgpt.com/codex/tasks/task_e_68e8019581c0832c8bdcf92fcd441420