### PR TITLE
docs: document mvp scope and roadmap

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 BMR Slicer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# BMR-Slicer
+# BMR Slicer
 
+## Objetivo
+O BMR Slicer é um projeto open source focado em fornecer um pipeline de fatiamento rápido e acessível para impressoras FDM. O MVP prioriza a preparação de G-code básico com calibração amigável para o usuário e integrações simples com ferramentas de produtividade.
+
+## Quickstart
+### Requisitos
+- Node.js 20.x
+- pnpm 9.x
+- Dependências nativas para Node-API (caso futuramente sejam adicionadas features em Rust/WASM)
+
+### Instalação e execução
+```bash
+pnpm install --filter slicer-web...
+pnpm --filter slicer-web dev
+```
+
+### Testes e qualidade
+```bash
+pnpm --filter slicer-web test
+pnpm --filter slicer-web lint
+```
+
+## Fórmulas principais
+- **Fluxo volumétrico de material (MVF)**: `MVF = (largura_da_extrusão × altura_da_camada × velocidade_de_impressão)`.
+- **Overhead de movimentos rápidos**: utilize o fator `overhead = (tempo_de_retração + tempo_de_viagem) / tempo_total_de_camada`. Esse coeficiente permite calibrar perfis levando em conta movimentos não extrusivos.
+- **Tempo estimado de impressão**: `tempo_total ≈ Σ (comprimento_do_caminho / velocidade) × (1 + overhead)`.
+
+## Calibração com a sua impressora
+1. **Coleta de dados base**: imprima um cubo de calibração (20×20×20 mm) com o perfil padrão. Anote tempo real, comprimento de filamento e peso da peça.
+2. **Ajuste de MVF**:
+   - Calcule o MVF real medindo o consumo de filamento (`massa / densidade / comprimento_da_trilha`).
+   - Compare com o MVF teórico fornecido pelo slicer (`largura × altura × velocidade`).
+   - Ajuste o multiplicador de fluxo até que o MVF real e o teórico estejam dentro de ±5%.
+3. **Calibração de overhead**:
+   - Meça o tempo total e subtraia o tempo estimado apenas de extrusão (comprimento / velocidade).
+   - O restante corresponde ao overhead. Atualize o fator `overhead` no perfil para compensar movimentações rápidas, retrações e acelerações.
+4. **Validação**: repita a impressão e confirme se o tempo previsto pelo slicer se aproxima (≤5%) do tempo real. Ajuste novamente se necessário.
+
+## Estrutura do repositório
+- `slicer-web/`: aplicação Next.js responsável pelo front-end, parsing de G-code e calibração interativa.
+- `docs/`: materiais auxiliares (screenshots, relatórios e especificações futuras).
+
+## Screenshots (placeholders)
+- ![Dashboard do MVP](docs/screenshots/mvp-dashboard-placeholder.png)
+- ![Assistente de calibração](docs/screenshots/calibration-placeholder.png)
+
+## Contribuição
+Contribuições são bem-vindas. Utilize Conventional Commits, siga as validações do lint-staged e abra PRs com contexto completo.
+
+## Licença
+Este projeto está licenciado sob os termos da [MIT License](./LICENSE).

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,3 @@
+# Screenshots
+
+Arquivos de captura de tela serão adicionados aqui conforme as interfaces forem implementadas.

--- a/slicer-web/ROADMAP.md
+++ b/slicer-web/ROADMAP.md
@@ -1,0 +1,28 @@
+# Roadmap
+
+## Fase 1 – MVP
+- Fluxo de upload de modelos STL e parâmetros básicos de fatiamento.
+- Pré-visualização simplificada em 3D com Three.js.
+- Persistência local com Dexie e sincronização mínima usando Web Workers.
+- Calibração guiada de MVF e overhead com base no fluxo de trabalho descrito no README.
+
+## Fase 2 – Suporte completo a G-code
+- Geração de G-code otimizada com comandos personalizados para impressoras BMR.
+- Exportação de relatórios em PDF (jsPDF) e planilhas (SheetJS).
+- Validação estruturada com Zod e testes automatizados em Vitest/Playwright.
+
+## Fase 3 – Shader de pré-visualização por camada
+- Renderização avançada de camadas usando shaders personalizados em Three.js.
+- Ferramentas de inspeção de falhas com filtros de velocidade, temperatura e fluxo.
+
+## Fase 4 – Integração WASM
+- Portar cálculos pesados para módulos WASM (Rust) com bindings via comlink.
+- Benchmark e ajustes de performance para reduzir o tempo de fatiamento.
+
+## Fase 5 – Backend com autenticação e multiusuário
+- API segura com controle de acesso baseado em papéis.
+- Perfis compartilhados e sincronização de presets entre dispositivos.
+
+## Fase 6 – Exportação para a nuvem
+- Integração com provedores de armazenamento (S3, GCS) para backup automático.
+- Webhooks e notificações sobre conclusão de fatiamento e jobs de impressão.


### PR DESCRIPTION
## Summary
- document the project objectives, quickstart, calibration workflow, and placeholders for UI screenshots in the repository README
- add a slicer-web roadmap outlining milestones from the MVP through future backend and cloud features
- provide the MIT license and scaffold a docs/screenshots directory for upcoming assets

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e8036819e0832cb8bd027c75f76233