### PR TITLE
feat: parse uploaded G-code to drive estimates

### DIFF
--- a/slicer-web/components/EstimateSummary.tsx
+++ b/slicer-web/components/EstimateSummary.tsx
@@ -9,6 +9,7 @@ export function EstimateSummary() {
   const summary = useViewerStore((state) => state.summary);
   const fileName = useViewerStore((state) => state.fileName) ?? 'slicer-report';
   const gcodeOverride = useViewerStore((state) => state.gcodeOverride);
+  const gcodeEnabled = useViewerStore((state) => state.gcodeEnabled);
 
   const metrics = useMemo(() => {
     if (!summary) {
@@ -55,7 +56,7 @@ export function EstimateSummary() {
         <div>
           <h2 style={{ margin: 0 }}>Print estimate</h2>
           <p style={{ margin: 0, color: '#94a3b8' }}>
-            {gcodeOverride
+            {gcodeEnabled && gcodeOverride
               ? 'Timing derived from uploaded G-code.'
               : 'Computed using adaptive slicing heuristics.'}
           </p>

--- a/slicer-web/lib/gcode.ts
+++ b/slicer-web/lib/gcode.ts
@@ -1,6 +1,8 @@
 export interface GcodeEstimate {
   time_s: number;
   filamentLen_mm: number;
+  extrusionDistance_mm: number;
+  travelDistance_mm: number;
 }
 
 interface Vector3 {
@@ -48,6 +50,8 @@ export function parseAndEstimate(content: string): GcodeEstimate {
 
   let time_s = 0;
   let filamentLen_mm = 0;
+  let extrusionDistance_mm = 0;
+  let travelDistance_mm = 0;
 
   const lines = content.split(/\r?\n/);
   for (const rawLine of lines) {
@@ -145,6 +149,14 @@ export function parseAndEstimate(content: string): GcodeEstimate {
     const dz = nextPosition.z - position.z;
     const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
 
+    if (distance > 0) {
+      if (extrusionDelta > 0) {
+        extrusionDistance_mm += distance;
+      } else {
+        travelDistance_mm += distance;
+      }
+    }
+
     if (distance > 0 && feedRateMmPerMin && feedRateMmPerMin > 0) {
       const feedRateMmPerSec = feedRateMmPerMin / 60;
       if (feedRateMmPerSec > 0) {
@@ -161,5 +173,5 @@ export function parseAndEstimate(content: string): GcodeEstimate {
     position.z = nextPosition.z;
   }
 
-  return { time_s, filamentLen_mm };
+  return { time_s, filamentLen_mm, extrusionDistance_mm, travelDistance_mm };
 }

--- a/slicer-web/tests/unit/gcode.parse.test.ts
+++ b/slicer-web/tests/unit/gcode.parse.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAndEstimate } from '../../lib/gcode';
+
+describe('parseAndEstimate', () => {
+  it('computes time and filament for absolute positioning with extrusion', () => {
+    const content = `
+      ; Simple square perimeter
+      G90 ; absolute positioning
+      M82 ; absolute extrusion
+      G1 X10 Y0 F1200
+      G1 X10 Y10 E1
+      G1 X0 Y10 E2 F600
+      G1 X0 Y0
+    `;
+
+    const estimate = parseAndEstimate(content);
+
+    expect(estimate.time_s).toBeCloseTo(3, 4);
+    expect(estimate.filamentLen_mm).toBeCloseTo(2, 4);
+    expect(estimate.extrusionDistance_mm).toBeCloseTo(20, 4);
+    expect(estimate.travelDistance_mm).toBeCloseTo(20, 4);
+  });
+
+  it('supports relative moves and extrusion, ignoring retractions for filament total', () => {
+    const content = `
+      G91 ; relative positioning
+      M83 ; relative extrusion
+      G1 X10 F1200
+      G1 Y10 E0.5
+      G1 X-10 E0.5
+      G1 Y-10 E-0.2 ; retraction should not add filament
+    `;
+
+    const estimate = parseAndEstimate(content);
+
+    expect(estimate.time_s).toBeCloseTo(2, 4);
+    expect(estimate.filamentLen_mm).toBeCloseTo(1, 4);
+    expect(estimate.extrusionDistance_mm).toBeCloseTo(20, 4);
+    expect(estimate.travelDistance_mm).toBeCloseTo(20, 4);
+  });
+
+  it('honors G92 resets for the extruder when using absolute extrusion', () => {
+    const content = `
+      G90
+      M82
+      G92 E0
+      G1 X0 Y0 F600
+      G1 X10 E5
+      G92 E0
+      G1 X20 E4
+    `;
+
+    const estimate = parseAndEstimate(content);
+
+    expect(estimate.time_s).toBeCloseTo(2, 4);
+    expect(estimate.filamentLen_mm).toBeCloseTo(9, 4);
+    expect(estimate.extrusionDistance_mm).toBeCloseTo(20, 4);
+    expect(estimate.travelDistance_mm).toBeCloseTo(0, 4);
+  });
+});

--- a/slicer-web/tests/unit/store.worker.test.ts
+++ b/slicer-web/tests/unit/store.worker.test.ts
@@ -188,6 +188,7 @@ describe('useViewerStore worker integration', () => {
 
     const stateAfterLoad = useViewerStore.getState();
     expect(stateAfterLoad.gcodeOverride?.fileName).toBe('override.gcode');
+    expect(stateAfterLoad.gcodeEnabled).toBe(true);
     expect(stateAfterLoad.summary?.durationMinutes).toBeCloseTo(10);
     expect(stateAfterLoad.effectiveBreakdown?.time_s).toBe(600);
     expect(stateAfterLoad.effectiveBreakdown?.filamentLen_mm).toBe(12);
@@ -196,6 +197,7 @@ describe('useViewerStore worker integration', () => {
 
     const stateAfterClear = useViewerStore.getState();
     expect(stateAfterClear.gcodeOverride).toBeUndefined();
+    expect(stateAfterClear.gcodeEnabled).toBe(false);
     expect(stateAfterClear.summary?.durationMinutes).toBeCloseTo(2);
     expect(stateAfterClear.effectiveBreakdown?.time_s).toBe(120);
     expect(stateAfterClear.effectiveBreakdown?.filamentLen_mm).toBe(3);


### PR DESCRIPTION
## Summary
- add travel and extrusion tracking to the G-code parser along with targeted fixtures
- persist a G-code override toggle in the viewer store and guard asynchronous uploads
- expose a "Usar G-code" control that displays override timing across the results UI

## Testing
- pnpm exec vitest run tests/unit/gcode.parse.test.ts tests/unit/store.worker.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e80454f90c832cbe71c8023d435948